### PR TITLE
Fixes reboots in noname

### DIFF
--- a/bootkit/main.go
+++ b/bootkit/main.go
@@ -97,8 +97,6 @@ func main() {
 		Privileged:  true,
 	}
 
-	fmt.Printf("%s / %s", cfg.username, cfg.password)
-
 	authConfig := types.AuthConfig{
 		Username: cfg.username,
 		Password: strings.TrimSuffix(cfg.password, "\n"),

--- a/noname.yaml
+++ b/noname.yaml
@@ -27,6 +27,7 @@ services:
     capabilities:
      - all
     net: host
+    pid: host
     mounts:
      - type: cgroup
        options: ["rw","nosuid","noexec","nodev","relatime"]


### PR DESCRIPTION
This provides the capability to enable reboots from another action by writing `/worker/reboot` to the `/worker` volume.